### PR TITLE
`use_build_context_synchronously` の warning の解消

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -155,7 +155,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1400;
+				LastUpgradeCheck = 1300;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {

--- a/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1400"
+   LastUpgradeVersion = "1300"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/lib/screens/home_page.dart
+++ b/lib/screens/home_page.dart
@@ -116,18 +116,23 @@ class _HomePageState extends ConsumerState<HomePage> {
   }
 }
 
-class BookCard extends ConsumerWidget {
+class BookCard extends ConsumerStatefulWidget {
   const BookCard({
     Key? key,
     required this.index,
     required this.wordbooks,
   }) : super(key: key);
 
-  final int index;
+final int index;
   final List<dynamic> wordbooks;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<ConsumerStatefulWidget> createState() => _BookCardState();
+}
+
+class _BookCardState extends ConsumerState<BookCard> {
+  @override
+  Widget build(BuildContext context) {
     if (ref.read(loadingStateProvider)) {
       return const CircularProgressIndicator();
     } else {
@@ -146,13 +151,15 @@ class BookCard extends ConsumerWidget {
             ref.read(loadingStateProvider.notifier).update(true);
             ref.read(maxPageProvider.notifier).getListLength();
             ref.read(wordbookInfoProvider.notifier).updateDBInfo(
-                  wordbooks[index]['db_name'],
-                  wordbooks[index]['api_key'],
-                  wordbooks[index]['db_id'],
+                  widget.wordbooks[widget.index]['db_name'],
+                  widget.wordbooks[widget.index]['api_key'],
+                  widget.wordbooks[widget.index]['db_id'],
                 );
             await ref.read(wordsListProvider.notifier).initState();
             const int firstPage = 1;
             ref.read(wordChoicesProvider.notifier).setRandomChoices(firstPage);
+            /// `context` が存在するか確認してから `Navigator.of(context)` を使うようにする。
+            if (!mounted) return;
             Navigator.of(context).pushNamed('/quiz');
             ref.read(loadingStateProvider.notifier).update(false);
           },
@@ -163,7 +170,7 @@ class BookCard extends ConsumerWidget {
             padding: const EdgeInsets.all(8.0),
             child: ListTile(
               title: Text(
-                wordbooks[index]['db_name'],
+                widget.wordbooks[widget.index]['db_name'],
                 style: const TextStyle(
                   fontSize: 19,
                 ),
@@ -171,7 +178,7 @@ class BookCard extends ConsumerWidget {
               subtitle: Padding(
                 padding: const EdgeInsets.only(top: 5),
                 child: Text(
-                  '前回正答率 ${wordbooks[index]['api_key']}', // TODO: api_keyを暫定的に表示
+                  '前回正答率 ${widget.wordbooks[widget.index]['api_key']}', // TODO: api_keyを暫定的に表示
                   style: const TextStyle(
                     fontSize: 15,
                   ),
@@ -188,9 +195,9 @@ class BookCard extends ConsumerWidget {
               trailing: InkWell(
                 onTap: () {
                   ref.read(wordbookInfoProvider.notifier).updateDBInfo(
-                        wordbooks[index]['db_name'],
-                        wordbooks[index]['api_key'],
-                        wordbooks[index]['db_id'],
+                        widget.wordbooks[widget.index]['db_name'],
+                        widget.wordbooks[widget.index]['api_key'],
+                        widget.wordbooks[widget.index]['db_id'],
                       );
                   Navigator.of(context).pushNamed('/wordbook_item');
                 },
@@ -209,7 +216,7 @@ class BookCard extends ConsumerWidget {
       builder: (BuildContext context) {
         return SimpleDialog(
           title: Text(
-            wordbooks[index]['db_name'],
+            widget.wordbooks[widget.index]['db_name'],
             style: const TextStyle(
               fontSize: 27,
             ),
@@ -228,7 +235,7 @@ class BookCard extends ConsumerWidget {
                 Navigator.pop(context);
                 await ref
                     .read(wordbookInfoListProvider.notifier)
-                    .removeFromList(wordbooks[index]['api_key']);
+                    .removeFromList(widget.wordbooks[widget.index]['api_key']);
               },
               child: const Text(
                 '削除',


### PR DESCRIPTION
## 目的

消せる warning が残っているとデバッグがしにくい

## 更新内容

`StatefulWidget` の `mounted` 変数を使って、もし `BuildContext` がちゃんと提供されない可能性があるとメソッドを実行しないようになるようにした。

## 関連するIssue等

Fixes #67 

## レビューポイント

特になし

## 留意事項

これからもこの warning が出たらこの辺を参考にすること良い。

https://stackoverflow.com/questions/69466478/waiting-asynchronously-for-navigator-push-linter-warning-appears-use-build


## 残課題
