### PR TITLE
[Freeze] 静的解析ルールのアップデート

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,10 +1,1 @@
-include: package:flutter_lints/flutter.yaml
-
-linter:
-  rules:
-    # avoid_print: false  # Uncomment to disable the `avoid_print` rule
-    prefer_single_quotes: true
-    require_trailing_commas: true
-    always_declare_return_types: true
-    always_specify_types: true
-    always_use_package_imports: true
+include: package:pedantic_mono/analysis_options.yaml

--- a/lib/client/words/main.dart
+++ b/lib/client/words/main.dart
@@ -8,8 +8,7 @@ import 'package:notion_wordbook/core/http/main.dart';
 /// MapからListへの変換はhelper/words/new_list.dartでやってる
 Future<ApiResult> getWordsData(String databaseID, String apiKey) async {
   try {
-    final HttpResult response =
-        await callPostMethod('$databaseID/query', apiKey);
+    final response = await callPostMethod('$databaseID/query', apiKey);
 
     // 取ってきた HttpResult がエラーの可能性があるので、それを管理。
     if (response.error != null) {
@@ -19,17 +18,17 @@ Future<ApiResult> getWordsData(String databaseID, String apiKey) async {
         json.decode(response.response!.body),
       ); //json->Map
     }
-  } catch (e) {
+  } on Exception catch (e) {
     return ApiResult.failure(e);
   }
 }
 
 Future<ApiResult> updateWordIsCorrect(
   String apiKey,
-  String pageId,
-  bool isCorrect,
-) async {
-  Map<String, dynamic> updatePayload = <String, dynamic>{
+  String pageId, {
+  required bool isCorrect,
+}) async {
+  final updatePayload = <String, dynamic>{
     'properties': <String, Map<String, bool>>{
       'Correct': <String, bool>{
         'checkbox': isCorrect,
@@ -37,17 +36,16 @@ Future<ApiResult> updateWordIsCorrect(
     }
   };
   try {
-    final HttpResult response =
-        await callPatchMethod(pageId, apiKey, updatePayload);
+    final response = await callPatchMethod(pageId, apiKey, updatePayload);
     return ApiResult.success(json.decode(response.response!.body)); //json->Map
-  } catch (e) {
+  } on Exception catch (e) {
     return ApiResult.failure(e);
   }
 }
 
 class ApiResult {
-  final Map<dynamic, dynamic>? body;
-  final Object? error;
-  ApiResult.success(this.body, {this.error});
   ApiResult.failure(this.error, {this.body});
+  ApiResult.success(this.body, {this.error});
+  final dynamic body;
+  final Object? error;
 }

--- a/lib/core/http/main.dart
+++ b/lib/core/http/main.dart
@@ -16,7 +16,7 @@ Future<HttpResult> callGetMethod(String url) async {
 
 Future<HttpResult> callPostMethod(String path, String apiKey) async {
   try {
-    http.Response response = await http.post(
+    final response = await http.post(
       Uri.parse(baseURL + path),
       headers: <String, String>{
         'Authorization': 'Bearer $apiKey',
@@ -40,7 +40,7 @@ Future<HttpResult> callPatchMethod(
   Map<dynamic, dynamic> payload,
 ) async {
   try {
-    http.Response response = await http.patch(
+    final response = await http.patch(
       Uri.parse(pageURL + path),
       headers: <String, String>{
         'Authorization': 'Bearer $apiKey',
@@ -60,8 +60,8 @@ Future<HttpResult> callPatchMethod(
 }
 
 class HttpResult {
+  HttpResult.failure(this.error, {this.response});
+  HttpResult.success(this.response, {this.error});
   final http.Response? response;
   final Object? error;
-  HttpResult.success(this.response, {this.error});
-  HttpResult.failure(this.error, {this.response});
 }

--- a/lib/helper/words/new_list.dart
+++ b/lib/helper/words/new_list.dart
@@ -3,17 +3,17 @@ import 'package:notion_wordbook/helper/words/retrieve.dart';
 import 'package:notion_wordbook/objects/models/word.dart';
 
 List<dynamic> extractWordsDataFromResponse(
-  Map<dynamic, dynamic> responseMap,
+dynamic responseMap,
 ) {
   return responseMap['results'].map((dynamic page) {
-    Map<String, dynamic> p = page['properties'];
+    final dynamic p = page['properties'];
     p.addAll(<String, dynamic>{'id': page['id']});
     return p;
   }).toList();
 }
 
 List<Word> newWordsList(Map<dynamic, dynamic> response) {
-  final List<dynamic> wordsData =
+  final wordsData =
       extractWordsDataFromResponse(response);
   return wordsData
       .map(

--- a/lib/objects/models/notion_key.dart
+++ b/lib/objects/models/notion_key.dart
@@ -1,7 +1,7 @@
 class WordbookInfo {
+
+  const WordbookInfo(this.dbName, this.apiKey, this.dbID);
   final String dbName;
   final String apiKey;
   final String dbID;
-
-  const WordbookInfo(this.dbName, this.apiKey, this.dbID);
 }

--- a/lib/objects/models/word.dart
+++ b/lib/objects/models/word.dart
@@ -1,13 +1,11 @@
 // 🌎 Project imports:
+// ignore_for_file: avoid_positional_boolean_parameters
+
+import 'package:flutter/material.dart';
 import 'package:notion_wordbook/objects/enums/word_tag.dart';
 
+@immutable
 class Word {
-  final String pageId;
-  final String spelling;
-  final String? meaning, exampleSentence, link;
-  // 正誤判定はAPIのJSON構造から必ず存在する
-  final bool correct;
-  final List<WordTag>? tags;
   const Word(
     this.pageId,
     this.spelling,
@@ -15,6 +13,14 @@ class Word {
     this.meaning,
     this.tags,
     this.exampleSentence,
-    this.link,
+    this.link, 
   );
+  final String pageId;
+  final String spelling;
+  final String? meaning;
+  final String? exampleSentence;
+  final String? link;
+  // 正誤判定はAPIのJSON構造から必ず存在する
+  final bool correct;
+  final List<WordTag>? tags;
 }

--- a/lib/screens/add_wordbook_page.dart
+++ b/lib/screens/add_wordbook_page.dart
@@ -18,7 +18,7 @@ class AddWordbookPage extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final WordbookInfo db = ref.read(wordbookInfoProvider);
+    final db = ref.read(wordbookInfoProvider);
     useEffect(
       () {
         dbNameController.text = db.dbName;

--- a/lib/screens/connecting_page.dart
+++ b/lib/screens/connecting_page.dart
@@ -10,11 +10,10 @@ import 'package:notion_wordbook/widgets/custom_textfield.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class ConnectingPage extends StatelessWidget {
+  ConnectingPage({Key? key}) : super(key: key);
   final FocusNode _focusNode = FocusNode();
   final TextEditingController apiKeyController = TextEditingController();
   final TextEditingController dbIDController = TextEditingController();
-
-  ConnectingPage({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) => Focus(
@@ -114,7 +113,8 @@ class ConnectButton extends ConsumerStatefulWidget {
     required this.apiKeyController,
     required this.dbIDController,
   }) : super(key: key);
-  final TextEditingController apiKeyController, dbIDController;
+  final TextEditingController apiKeyController;
+  final TextEditingController dbIDController;
 
   @override
   ConsumerState<ConsumerStatefulWidget> createState() => _ConnectButtonState();
@@ -130,7 +130,7 @@ class _ConnectButtonState extends ConsumerState<ConnectButton> {
         onTap: () async {
           // ロード中だよ
           ref.read(loadingNotifierProvider.notifier).start();
-          DBStatus dbStatus =
+          final dbStatus =
               await ref.read(wordbookInfoProvider.notifier).setDBInfo(
                     widget.apiKeyController.text,
                     widget.dbIDController.text,
@@ -145,7 +145,9 @@ class _ConnectButtonState extends ConsumerState<ConnectButton> {
             connectionResultMessage(null);
 
             /// `context` が存在するか確認してから `Navigator.of(context)` を使うようにする。
-            if (!mounted) return;
+            if (!mounted) {
+              return;
+            }
             Navigator.of(context).popUntil(ModalRoute.withName('/'));
             // ページ遷移につき初期化することで次回の入力の時にデータが残っていることを防ぐ。
             ref.read(wordbookInfoProvider.notifier).updateDBInfo('', '', '');
@@ -160,7 +162,9 @@ class _ConnectButtonState extends ConsumerState<ConnectButton> {
 
   void connectionResultMessage(DBStatus? dbStatus) {
     /// `context` が存在するか確認してから `Navigator.of(context)` を使うようにする。
-    if (!mounted) return;
+    if (!mounted) {
+      return;
+    }
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
         content: dbStatus != null

--- a/lib/screens/home_page.dart
+++ b/lib/screens/home_page.dart
@@ -21,7 +21,7 @@ class _HomePageState extends ConsumerState<HomePage> {
   @override
   void initState() {
     super.initState();
-    Future<void>.microtask(() => _loadWordList());
+    Future<void>.microtask(_loadWordList);
   }
 
   @override
@@ -30,15 +30,15 @@ class _HomePageState extends ConsumerState<HomePage> {
   }
 
   Future<void> _loadWordList() async {
-    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    final prefs = await SharedPreferences.getInstance();
     ref.read(wordbookInfoListProvider.notifier).getWordbookList(prefs);
   }
 
   @override
   Widget build(BuildContext context) {
-    Future<void>.microtask(() => _loadWordList());
+    Future<void>.microtask(_loadWordList);
 
-    final AsyncValue<List<dynamic>> wordbooks =
+    final wordbooks =
         ref.watch(wordbookInfoListProvider);
     return Scaffold(
       appBar: AppBar(
@@ -68,7 +68,7 @@ class _HomePageState extends ConsumerState<HomePage> {
               ),
             ),
             wordbooks.when(
-              data: (List<dynamic> data) => ListView.builder(
+              data: (List<Map<String, String>> data) => ListView.builder(
                 shrinkWrap: true,
                 physics: const NeverScrollableScrollPhysics(),
                 itemCount: data.length,
@@ -114,7 +114,7 @@ class BookCard extends ConsumerStatefulWidget {
   }) : super(key: key);
 
   final int index;
-  final List<dynamic> wordbooks;
+  final List<Map<String, String>> wordbooks;
 
   @override
   ConsumerState<ConsumerStatefulWidget> createState() => _BookCardState();
@@ -132,22 +132,24 @@ class _BookCardState extends ConsumerState<BookCard> {
         ),
         child: InkWell(
           onTap: () async {
-            ref.read(loadingStateProvider.notifier).update(true);
+            ref.read(loadingStateProvider.notifier).startLoading();
             ref.read(maxPageProvider.notifier).getListLength();
             ref.read(wordbookInfoProvider.notifier).updateDBInfo(
-                  widget.wordbooks[widget.index]['db_name'],
-                  widget.wordbooks[widget.index]['api_key'],
-                  widget.wordbooks[widget.index]['db_id'],
+                  widget.wordbooks[widget.index]['db_name']!,
+                  widget.wordbooks[widget.index]['api_key']!,
+                  widget.wordbooks[widget.index]['db_id']!,
                 );
             await ref.read(wordsListProvider.notifier).initState();
             ref.read(currentPageProvider.notifier).initState();
-            const int firstPage = 1;
+            const firstPage = 1;
             ref.read(wordChoicesProvider.notifier).setRandomChoices(firstPage);
 
             /// `context` が存在するか確認してから `Navigator.of(context)` を使うようにする。
-            if (!mounted) return;
-            Navigator.of(context).pushNamed('/quiz');
-            ref.read(loadingStateProvider.notifier).update(false);
+            if (!mounted) {
+              return;
+            }
+            await Navigator.of(context).pushNamed('/quiz');
+            ref.read(loadingStateProvider.notifier).stopLoading();
           },
           onLongPress: () {
             longPressDialog(context, ref);
@@ -156,7 +158,7 @@ class _BookCardState extends ConsumerState<BookCard> {
             padding: smallPadding,
             child: ListTile(
               title: Text(
-                widget.wordbooks[widget.index]['db_name'],
+                widget.wordbooks[widget.index]['db_name']!,
                 style: Theme.of(context).textTheme.titleMedium,
               ),
               subtitle: Padding(
@@ -167,7 +169,7 @@ class _BookCardState extends ConsumerState<BookCard> {
                 ),
               ),
               leading: const Padding(
-                padding: EdgeInsets.symmetric(vertical: 16.0),
+                padding: EdgeInsets.symmetric(vertical: 16),
                 child: Icon(
                   Icons.circle_sharp,
                   color: Colors.white,
@@ -177,9 +179,9 @@ class _BookCardState extends ConsumerState<BookCard> {
               trailing: InkWell(
                 onTap: () {
                   ref.read(wordbookInfoProvider.notifier).updateDBInfo(
-                        widget.wordbooks[widget.index]['db_name'],
-                        widget.wordbooks[widget.index]['api_key'],
-                        widget.wordbooks[widget.index]['db_id'],
+                        widget.wordbooks[widget.index]['db_name']!,
+                        widget.wordbooks[widget.index]['api_key']!,
+                        widget.wordbooks[widget.index]['db_id']!,
                       );
                   Navigator.of(context).pushNamed('/wordbook_item');
                 },

--- a/lib/screens/hook_test_page.dart
+++ b/lib/screens/hook_test_page.dart
@@ -32,15 +32,15 @@ class HookPageState extends State<HookPage> {
   }
 
   Future<void> _getDataFromSP() async {
-    SharedPreferences prefs = await SharedPreferences.getInstance();
+    final prefs = await SharedPreferences.getInstance();
     setState(() {
       _counter = prefs.getInt('counter') ?? 0;
     });
   }
 
-  void _setCounterValue() async {
-    SharedPreferences prefs = await SharedPreferences.getInstance();
-    prefs.setInt('counter', _counter);
+  Future<void> _setCounterValue() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt('counter', _counter);
   }
 
   void _incrementCounter() {

--- a/lib/screens/quiz_page/components/answer_candidate_card.dart
+++ b/lib/screens/quiz_page/components/answer_candidate_card.dart
@@ -48,19 +48,21 @@ class AnswerCandidateCardState extends ConsumerState<AnswerCandidateCard> {
         child: InkWell(
           onTap: () async {
             if (widget.currentPage >= widget.maxPage) {
-              final List<Word> wordList = ref.read(wordsListProvider);
+              final wordList = ref.read(wordsListProvider);
               // ここで学んだ単語数をロードする。
               await ref
                   .read(wordsLearnedProvider.notifier)
                   .update(wordList.length);
-              if (!mounted) return;
-              Navigator.of(context).pushNamed('/result');
+              if (!mounted) {
+                return;
+              }
+              await Navigator.of(context).pushNamed('/result');
               return;
             }
             ref.read(currentPageProvider.notifier).pageCount();
-            final int nextPage = widget.currentPage + 1;
+            final nextPage = widget.currentPage + 1;
             ref.read(wordChoicesProvider.notifier).setRandomChoices(nextPage);
-            Navigator.of(context).pushNamed('/quiz');
+            await Navigator.of(context).pushNamed('/quiz');
           },
           child: ListTile(
             title: Text(
@@ -69,17 +71,19 @@ class AnswerCandidateCardState extends ConsumerState<AnswerCandidateCard> {
             ),
             onTap: () async {
               if (widget.currentPage >= widget.maxPage) {
-                final List<Word> wordList = ref.read(wordsListProvider);
+                final wordList = ref.read(wordsListProvider);
                 // ここで学んだ単語数をロードする。
                 await ref
                     .read(wordsLearnedProvider.notifier)
                     .update(wordList.length);
-                if (!mounted) return;
-                Navigator.of(context).pushNamed('/result');
+                if (!mounted) {
+                  return;
+                }
+                await Navigator.of(context).pushNamed('/result');
                 return;
               }
               ref.read(currentPageProvider.notifier).pageCount();
-              final int nextPage = widget.currentPage + 1;
+              final nextPage = widget.currentPage + 1;
 
               /// 次ページの選択肢をランダムに取得
               ref.read(wordChoicesProvider.notifier).setRandomChoices(nextPage);
@@ -89,10 +93,10 @@ class AnswerCandidateCardState extends ConsumerState<AnswerCandidateCard> {
                     widget.currentPage - 1,
                     widget.word[widget.index] == widget.correctWord.spelling,
                   );
-              Navigator.of(context).pushNamed('/quiz');
+              await Navigator.of(context).pushNamed('/quiz');
             },
             leading: Padding(
-              padding: const EdgeInsets.only(top: 12.0, bottom: 12.0, left: 6),
+              padding: const EdgeInsets.only(top: 12, bottom: 12, left: 6),
               child: Text(
                 (widget.index + 1).toString(),
                 style: const TextStyle(

--- a/lib/screens/quiz_page/components/definition_text.dart
+++ b/lib/screens/quiz_page/components/definition_text.dart
@@ -1,7 +1,6 @@
 // 🐦 Flutter imports:
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:notion_wordbook/objects/models/word.dart';
 import 'package:notion_wordbook/viewmodels/page_controllers.dart';
 import 'package:notion_wordbook/viewmodels/word_list_controller.dart';
 
@@ -12,11 +11,10 @@ class DefinitionText extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final int currentPage = ref.read(currentPageProvider);
-    final Word word = ref.read(wordsListProvider)[currentPage - 1];
+    final currentPage = ref.read(currentPageProvider);
+    final word = ref.read(wordsListProvider)[currentPage - 1];
     return RichText(
       textAlign: TextAlign.center,
-      softWrap: true,
       text: TextSpan(
         text: word.meaning,
         style: const TextStyle(

--- a/lib/screens/quiz_page/components/interrupt_message.dart
+++ b/lib/screens/quiz_page/components/interrupt_message.dart
@@ -30,7 +30,6 @@ class InterruptMessage extends StatelessWidget {
         decoration: BoxDecoration(
           border: Border(
             bottom: BorderSide(
-              width: 1,
               color: Theme.of(context).colorScheme.background,
             ),
           ),

--- a/lib/screens/quiz_page/components/progress_bar.dart
+++ b/lib/screens/quiz_page/components/progress_bar.dart
@@ -1,7 +1,6 @@
 // 🐦 Flutter imports:
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:notion_wordbook/objects/models/word.dart';
 import 'package:notion_wordbook/viewmodels/page_controllers.dart';
 import 'package:notion_wordbook/viewmodels/word_list_controller.dart';
 
@@ -12,9 +11,9 @@ class ProgressBar extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final int currentPage = ref.read(currentPageProvider);
-    final List<Word> wordsList = ref.read(wordsListProvider);
-    final int maxPage = wordsList.length;
+    final currentPage = ref.read(currentPageProvider);
+    final wordsList = ref.read(wordsListProvider);
+    final maxPage = wordsList.length;
     return LinearProgressIndicator(
       value: currentPage / maxPage,
       minHeight: 5,

--- a/lib/screens/quiz_page/components/progress_text.dart
+++ b/lib/screens/quiz_page/components/progress_text.dart
@@ -2,7 +2,6 @@
 import 'package:flutter/material.dart';
 // 📦 Package imports:
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:notion_wordbook/objects/models/word.dart';
 // 🌎 Project imports:
 import 'package:notion_wordbook/viewmodels/page_controllers.dart';
 import 'package:notion_wordbook/viewmodels/word_list_controller.dart';
@@ -14,9 +13,9 @@ class ProgressText extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final int currentPage = ref.read(currentPageProvider);
-    final List<Word> wordsList = ref.read(wordsListProvider);
-    final int maxPage = wordsList.length;
+    final currentPage = ref.read(currentPageProvider);
+    final wordsList = ref.read(wordsListProvider);
+    final maxPage = wordsList.length;
     return Text(
       '$currentPage / $maxPage',
       style: Theme.of(context).textTheme.titleLarge,

--- a/lib/screens/quiz_page/quiz_page.dart
+++ b/lib/screens/quiz_page/quiz_page.dart
@@ -18,13 +18,13 @@ class QuizPage extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final List<Word> wordsList = ref.read(wordsListProvider);
-    final int currentPage = ref.read(currentPageProvider);
+    final wordsList = ref.read(wordsListProvider);
+    final currentPage = ref.read(currentPageProvider);
     // 正誤判定に使う
     // ignore: unused_local_variable
-    final Word correctWord = wordsList[currentPage - 1];
-    final int maxPage = wordsList.length;
-    final List<String> word = ref.read(wordChoicesProvider);
+    final correctWord = wordsList[currentPage - 1];
+    final maxPage = wordsList.length;
+    final word = ref.read(wordChoicesProvider);
     if (ref.watch(loadingStateProvider)) {
       return const CircularProgressIndicator();
     } else {

--- a/lib/screens/test_result/components/result_button.dart
+++ b/lib/screens/test_result/components/result_button.dart
@@ -26,7 +26,7 @@ class ResultButton extends ConsumerWidget {
   void showMissedOnly(WidgetRef ref) {
     ref
         .read(resultListModeProvider.notifier)
-        .update(((ResultListMode state) => state = ResultListMode.incorrect));
+        .update((ResultListMode state) => state = ResultListMode.incorrect);
   }
 
   void showAll(WidgetRef ref) {
@@ -51,7 +51,7 @@ class ResultButton extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return Padding(
-      padding: const EdgeInsets.all(5.0),
+      padding: const EdgeInsets.all(5),
       child: SizedBox(
         width: isLarge ? 300 : 145,
         height: 50,
@@ -75,7 +75,6 @@ class ResultButton extends ConsumerWidget {
                 ? Theme.of(context).colorScheme.secondary
                 : Colors.white,
             side: const BorderSide(
-              color: Colors.black,
               width: 0.5,
             ),
             shape: const StadiumBorder(),

--- a/lib/screens/test_result/components/result_list_item.dart
+++ b/lib/screens/test_result/components/result_list_item.dart
@@ -14,12 +14,11 @@ class ResultListItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
+    return DecoratedBox(
       decoration: BoxDecoration(
         border: Border(
           bottom: BorderSide(
             color: Theme.of(context).colorScheme.outline,
-            width: 1.0,
           ),
         ),
       ),
@@ -41,7 +40,7 @@ class ResultListItem extends StatelessWidget {
                   ),
                   Padding(
                     padding: const EdgeInsets.only(
-                      top: 5.0,
+                      top: 5,
                     ),
                     child: Text(
                       meaning,

--- a/lib/screens/test_result/test_result_page.dart
+++ b/lib/screens/test_result/test_result_page.dart
@@ -15,30 +15,29 @@ class TestResultPage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final List<Word> wordList = ref.read(wordsListProvider);
-    final List<Word> incorrectList =
+    final wordList = ref.read(wordsListProvider);
+    final incorrectList =
         wordList.where((Word word) => word.correct == false).toList();
-    final int correctCount =
+    final correctCount =
         wordList.where((Word word) => word.correct == true).length;
 
     /// 学習状況を更新して、 [wordsLearned] に保存する。
-    final int wordsLearned = ref.read(wordsLearnedProvider);
+    final wordsLearned = ref.read(wordsLearnedProvider);
 
-    ResultListMode resultListMode = ref.watch(resultListModeProvider);
+    final resultListMode = ref.watch(resultListModeProvider);
     return Scaffold(
       appBar: AppBar(
         shape: Border(
           bottom: BorderSide(
             color: Theme.of(context).colorScheme.outline,
-            width: 1.0,
           ),
         ),
-        elevation: 0.0,
+        elevation: 0,
         backgroundColor: Colors.transparent,
         leading: Padding(
           padding: const EdgeInsets.only(
             left: 20,
-            top: 5.0,
+            top: 5,
           ),
           child: IconButton(
             onPressed: () {
@@ -71,7 +70,7 @@ class TestResultPage extends ConsumerWidget {
             ),
             Padding(
               padding: const EdgeInsets.only(
-                top: 5.0,
+                top: 5,
               ),
               child: Text(
                 '${wordsLearned - wordList.length}→$wordsLearned単語',
@@ -143,9 +142,8 @@ class TestResultPage extends ConsumerWidget {
                         : resultListMode == ResultListMode.incorrect
                             ? incorrectList[index].meaning ?? ''
                             : '',
-                    isMissed: resultListMode == ResultListMode.all
-                        ? !wordList[index].correct
-                        : true,
+                    isMissed: resultListMode != ResultListMode.all ||
+                        !wordList[index].correct,
                   );
                 },
               ),

--- a/lib/screens/wordbook_item_page.dart
+++ b/lib/screens/wordbook_item_page.dart
@@ -17,7 +17,7 @@ class WordBookItemPage extends HookConsumerWidget {
       },
       <Object>[],
     );
-    final List<Word> wordsList = ref.read(wordsListProvider);
+    final wordsList = ref.read(wordsListProvider);
 
     return Scaffold(
       appBar: AppBar(
@@ -54,7 +54,7 @@ class WordCard extends StatelessWidget {
   Widget build(BuildContext context) {
     return Card(
       child: Padding(
-        padding: const EdgeInsets.all(8.0),
+        padding: const EdgeInsets.all(8),
         child: ListTile(
           title: Text(
             words[index].spelling,

--- a/lib/viewmodels/load_state_controller.dart
+++ b/lib/viewmodels/load_state_controller.dart
@@ -4,7 +4,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 class LoadingStateViewModel extends StateNotifier<bool> {
   LoadingStateViewModel() : super(false);
 
-  void update(bool s) => state = s;
+  void startLoading() => state = true;
+  void stopLoading() => state = false;
 }
 
 final StateNotifierProvider<LoadingStateViewModel, bool> loadingStateProvider =

--- a/lib/viewmodels/page_controllers.dart
+++ b/lib/viewmodels/page_controllers.dart
@@ -1,7 +1,5 @@
 // 📦 Package imports:
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-// 🌎 Project imports:
-import 'package:notion_wordbook/objects/models/word.dart';
 import 'package:notion_wordbook/viewmodels/word_list_controller.dart';
 
 class MaxPageNotifier extends StateNotifier<int> {
@@ -9,7 +7,7 @@ class MaxPageNotifier extends StateNotifier<int> {
   Ref ref;
 
   void getListLength() {
-    final List<Word> wordList = ref.read(wordsListProvider);
+    final wordList = ref.read(wordsListProvider);
     state = wordList.length;
   }
 }

--- a/lib/viewmodels/word_choices_controller.dart
+++ b/lib/viewmodels/word_choices_controller.dart
@@ -6,7 +6,7 @@ class WordChoicesViewModel extends StateNotifier<List<String>> {
   Ref ref;
 
   void setRandomChoices(int currentPage) {
-    final List<String> wordChoices =
+    final wordChoices =
         ref.read(wordsListProvider.notifier).getRandomWords(currentPage);
     wordChoices.shuffle();
     state = wordChoices;

--- a/lib/viewmodels/word_list_controller.dart
+++ b/lib/viewmodels/word_list_controller.dart
@@ -3,7 +3,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:notion_wordbook/client/words/main.dart';
 // 🌎 Project imports:
 import 'package:notion_wordbook/helper/words/new_list.dart';
-import 'package:notion_wordbook/objects/models/notion_key.dart';
 import 'package:notion_wordbook/objects/models/word.dart';
 import 'package:notion_wordbook/viewmodels/wordbook_info.dart';
 
@@ -13,22 +12,23 @@ class WordsListViewModel extends StateNotifier<List<Word>> {
   Ref ref;
 
   Future<void> initState() async {
-    final WordbookInfo wordbookInfo = ref.read(wordbookInfoProvider);
-    final ApiResult result =
-        await getWordsData(wordbookInfo.dbID, wordbookInfo.apiKey);
+    final wordbookInfo = ref.read(wordbookInfoProvider);
+    final result = await getWordsData(wordbookInfo.dbID, wordbookInfo.apiKey);
     state = newWordsList(result.body!);
   }
 
   List<String> getRandomWords(int currentPage) {
-    final int maxPage = state.length;
+    final maxPage = state.length;
 
     // TODO: maxPageを超えたときの挙動を考える
     // TODO: 同じ文字列の単語が入ったときの挙動を考える
-    if (currentPage > maxPage) return <String>['above', 'max', 'error', 'w'];
+    if (currentPage > maxPage) {
+      return <String>['above', 'max', 'error', 'w'];
+    }
 
     /// 単語帳内の単語の総数が4つ未満だったら指定の単語を選択肢として表示する
     if (maxPage < 4) {
-      List<String> choices = <String>[
+      final choices = <String>[
         state[currentPage - 1].spelling,
         'notion',
         'abstract',
@@ -39,16 +39,16 @@ class WordsListViewModel extends StateNotifier<List<Word>> {
     }
 
     /// 単語帳内の単語から今のページの答えを除いて、シャッフルする
-    List<int> list = <int>[];
-    for (int i = 0; i < maxPage; i++) {
-      if (currentPage == i + 1) continue;
+    final list = <int>[];
+    for (var i = 0; i < maxPage; i++) {
+      if (currentPage == i + 1) {}
       list.add(i + 1);
     }
     list.shuffle();
 
     /// シャッフルした配列から前3つを取り出して、現在の答えの単語を追加する
-    List<String> choices = <String>[state[currentPage - 1].spelling];
-    for (int i = 0; i < 3; i++) {
+    final choices = <String>[state[currentPage - 1].spelling];
+    for (var i = 0; i < 3; i++) {
       choices.add(state[list[i] - 1].spelling);
     }
 
@@ -56,10 +56,10 @@ class WordsListViewModel extends StateNotifier<List<Word>> {
   }
 
   void updateIsCorrect(int indexNumber, bool isCorrect) {
-    final WordbookInfo wordbookInfo = ref.read(wordbookInfoProvider);
+    final wordbookInfo = ref.read(wordbookInfoProvider);
 
-    List<Word> updatedState = <Word>[];
-    for (int i = 0; i < state.length; i++) {
+    final updatedState = <Word>[];
+    for (var i = 0; i < state.length; i++) {
       if (i != indexNumber) {
         updatedState.add(state[i]);
       } else {
@@ -89,21 +89,20 @@ final StateNotifierProvider<WordsListViewModel, List<Word>> wordsListProvider =
 
 final FutureProvider<List<Word>> wordsListFutureProvider =
     FutureProvider<List<Word>>((FutureProviderRef<List<Word>> ref) async {
-  final WordbookInfo wordbookInfo = ref.read(wordbookInfoProvider);
-  final ApiResult wordListResult =
+  final wordbookInfo = ref.read(wordbookInfoProvider);
+  final wordListResult =
       await getWordsData(wordbookInfo.dbID, wordbookInfo.apiKey);
-  final List<Word> wordList = newWordsList(wordListResult.body!);
+  final wordList = newWordsList(wordListResult.body!);
 
   return wordList;
 });
-
 
 /// [previousCorrectCountProvider] は前回のテストで正解した単語の数を状態として持つ
 class PreviousCorrectCountNotifier extends StateNotifier<int> {
   PreviousCorrectCountNotifier() : super(0);
 
   void initState(WidgetRef ref) {
-    final List<Word> wordList = ref.read(wordsListProvider);
+    final wordList = ref.read(wordsListProvider);
     state = wordList.where((Word word) => word.correct == true).length;
   }
 }

--- a/lib/viewmodels/words_learned_controller.dart
+++ b/lib/viewmodels/words_learned_controller.dart
@@ -5,21 +5,21 @@ class WordsLearnedNotifier extends StateNotifier<int> {
   WordsLearnedNotifier() : super(0);
 
   Future<void> loadState() async {
-    final DateTime today =
+    final today =
         DateTime(DateTime.now().year, DateTime.now().month, DateTime.now().day);
-    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    final prefs = await SharedPreferences.getInstance();
     state = prefs.getInt('wordsLearned$today') ?? 0;
   }
 
   Future<void> update(int numberOfWordsLearned) async {
-    final DateTime today =
+    final today =
         DateTime(DateTime.now().year, DateTime.now().month, DateTime.now().day);
     // まず状態を今日の日付のものにする。
     await loadState();
 
-    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    final prefs = await SharedPreferences.getInstance();
     state += numberOfWordsLearned;
-    prefs.setInt(
+    await prefs.setInt(
       'wordsLearned$today',
       state,
     );

--- a/lib/widgets/custom_textfield.dart
+++ b/lib/widgets/custom_textfield.dart
@@ -19,7 +19,7 @@ class CustomTextField extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final bool obscuritySwitch = ref.watch(obscuritySwitchProvider);
+    final obscuritySwitch = ref.watch(obscuritySwitchProvider);
     return Container(
       margin: const EdgeInsets.only(bottom: 40),
       child: Column(
@@ -55,7 +55,7 @@ class CustomTextField extends HookConsumerWidget {
               labelStyle: const TextStyle(fontSize: 16),
               floatingLabelStyle: MaterialStateTextStyle.resolveWith(
                   (Set<MaterialState> states) {
-                final Color color = states.contains(MaterialState.error)
+                final color = states.contains(MaterialState.error)
                     ? Theme.of(context).errorColor
                     : Colors.purple;
                 return TextStyle(color: color, fontSize: 20);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -212,6 +212,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
+  pedantic_mono:
+    dependency: "direct dev"
+    description:
+      name: pedantic_mono
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.19.2"
   platform:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,6 +26,7 @@ dev_dependencies:
   flutter_lints: ^2.0.1
   flutter_test:
     sdk: flutter
+  pedantic_mono: ^1.19.2
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
## 目的

`pedantic_mono` は日本の flutter 界隈では広く使われているため、このスタイルの静的解析に慣れると後々良さそうと思う。

## 更新内容

- `pubspec.yaml` に `pedantic_mono` を追加
-  `analysis_options.yaml` に `pedantic_mono` パッケージをインポート
- ちょっと直してみた

## 関連するIssue等

## レビューポイント

なし

## 留意事項

## 残課題

エラーと warning の解決
