### PR TITLE
[Freezed] APIKey のエンクリプト

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -47,7 +47,7 @@ android {
         applicationId "com.norihanda.notion_wordbook"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-build-configuration.
-        minSdkVersion flutter.minSdkVersion
+        minSdkVersion 18
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -4,7 +4,8 @@
         android:label="notion_wordbook"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"
-        android:allowBackup="false">
+        android:allowBackup="false"
+        android:fullBackupContent="false">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,7 +3,8 @@
    <application
         android:label="notion_wordbook"
         android:name="${applicationName}"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:allowBackup="false">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/lib/screens/home_page.dart
+++ b/lib/screens/home_page.dart
@@ -1,5 +1,6 @@
 // 🐦 Flutter imports:
 import 'package:flutter/material.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:notion_wordbook/viewmodels/load_state_controller.dart';
 // 🌎 Project imports:
@@ -8,7 +9,6 @@ import 'package:notion_wordbook/viewmodels/word_choices_controller.dart';
 import 'package:notion_wordbook/viewmodels/word_list_controller.dart';
 import 'package:notion_wordbook/viewmodels/wordbook_info.dart';
 import 'package:notion_wordbook/widgets/padding.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
 class HomePage extends ConsumerStatefulWidget {
   const HomePage({Key? key}) : super(key: key);
@@ -30,8 +30,9 @@ class _HomePageState extends ConsumerState<HomePage> {
   }
 
   Future<void> _loadWordList() async {
-    final SharedPreferences prefs = await SharedPreferences.getInstance();
-    ref.read(wordbookInfoListProvider.notifier).getWordbookList(prefs);
+    const FlutterSecureStorage secureStorage = FlutterSecureStorage();
+    final Map<String, String> secureData = await secureStorage.readAll();
+    ref.read(wordbookInfoListProvider.notifier).getWordbookList(secureData);
   }
 
   @override
@@ -72,15 +73,15 @@ class _HomePageState extends ConsumerState<HomePage> {
             wordbooks.when(
               data: (List<dynamic> data) => data.isNotEmpty
                   ? ListView.builder(
-                shrinkWrap: true,
-                physics: const NeverScrollableScrollPhysics(),
-                itemCount: data.length,
-                itemBuilder: (BuildContext context, int index) {
-                  return BookCard(
-                    index: index,
-                    wordbooks: data,
-                  );
-                },
+                      shrinkWrap: true,
+                      physics: const NeverScrollableScrollPhysics(),
+                      itemCount: data.length,
+                      itemBuilder: (BuildContext context, int index) {
+                        return BookCard(
+                          index: index,
+                          wordbooks: data,
+                        );
+                      },
                     )
                   : const Padding(
                       padding: EdgeInsets.all(40),

--- a/lib/viewmodels/wordbook_info.dart
+++ b/lib/viewmodels/wordbook_info.dart
@@ -16,12 +16,14 @@ class WordbookInfoListViewModel
   WordbookInfoListViewModel()
       : super(const AsyncValue<List<dynamic>>.data(<dynamic>[]));
 
-  void getWordbookList(SharedPreferences prefs) {
-    if (!prefs.containsKey('wordbooks')) {
+  void getWordbookList(Map<String, String> secureData) async {
+    final bool hasWordbook = secureData.containsKey('hasWordbook');
+    if (!hasWordbook) {
       return;
     }
     List<dynamic> storedData =
-        json.decode(prefs.getString('wordbooks') ?? '')['wordbooks'];
+        json
+        .decode(secureData['wordbooks'] ?? '')['wordbooks'] as List<dynamic>;
     state = AsyncValue<List<dynamic>>.data(storedData);
   }
 

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -6,9 +6,13 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) flutter_secure_storage_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterSecureStorageLinuxPlugin");
+  flutter_secure_storage_linux_plugin_register_with_registrar(flutter_secure_storage_linux_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  flutter_secure_storage_linux
   url_launcher_linux
 )
 

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,10 +5,12 @@
 import FlutterMacOS
 import Foundation
 
+import flutter_secure_storage_macos
 import shared_preferences_macos
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  FlutterSecureStorageMacosPlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStorageMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -104,6 +104,48 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.4"
+  flutter_secure_storage:
+    dependency: "direct main"
+    description:
+      name: flutter_secure_storage
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "5.0.2"
+  flutter_secure_storage_linux:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_linux
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.0"
+  flutter_secure_storage_macos:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_macos
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.0"
+  flutter_secure_storage_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
+  flutter_secure_storage_web:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.2"
+  flutter_secure_storage_windows:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.2"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
     sdk: flutter
   flutter_hooks: ^0.18.5+1
   flutter_riverpod: ^1.0.3
+  flutter_secure_storage: ^5.0.2
   hooks_riverpod: ^1.0.3
   http: ^0.13.4
   import_sorter: ^4.6.0

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -6,9 +6,12 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  FlutterSecureStorageWindowsPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
   UrlLauncherWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  flutter_secure_storage_windows
   url_launcher_windows
 )
 


### PR DESCRIPTION
## 目的

api_key が普通の shared_preferences に保存されていると、他者から覗けるかもしれないから。

## 更新内容

- `flutter_secure_storage` のインストール
- `android/app/build.gradle` の `defaultConfig` の `minSdkVersion` を `flutter.minSdkVersion` から `18` に変更
- `android/app/src/main/AndroidManifest.xml` の `<application>` タグに `android:allowBackup="false` を付け足した。（[参考](https://developer.android.com/guide/topics/data/autobackup#EnablingAutoBackup)）
- 同じ箇所に `android:fullBackupContent="false"` を追加した。
- `home_page.dart` の `_HomePageState` クラスの中の `_loadWordList()` メソッドで `SharedPreferences` をインスタンス化させていたところを、 `FlutterSecureStorage` をインスタンス化させて、その中身を `WordbookInfoViewModel` に送ることにした。

## 関連するIssue等

## レビューポイント

## 留意事項

## 残課題

- ログイン機能があって初めて使えるっぽいンゴ。
